### PR TITLE
Feat: Animation system — ball becomes entity, animates along ShotResu…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Project Overview
 A Minecraft golf mod built on **NeoForge**, targeting **Minecraft 1.21.x**.
 Players hit a golf ball block using club items, the ball simulates a full physics path
-server-side, stores the result in a BlockEntity, and (eventually) animates along that path client-side.
+server-side, stores the result in a BlockEntity, and animates along that path client-side via a temporary entity.
 
 ## Mod Package
 ```
@@ -23,8 +23,10 @@ net.astellismodding.golfwithmates
 | `TrajectoryCalculator.java` | `util` | Iterative simulation, returns `ShotResult` |
 | `ClubUtils.java` | `util` | Stat lookup only — `isClub`, `getShotType`, `getVelocity`, `getBounciness` |
 | `ShotType.java` | `util` | PUTTER, IRON, WEDGE, DRIVER enum |
-| `GolfBallBlockEntity.java` | `block/entity` | Stores `ShotResult`, puttCounter, isActive, animationTick (pinned) |
-| `GolfBallBlock.java` | `block/custom` | Wires TrajectoryCalculator on swing, teleports ball to REST node |
+| `GolfBallBlockEntity.java` | `block/entity` | Stores `ShotResult`, puttCounter, isActive, sub-cell position, NBT + sync |
+| `GolfBallBlock.java` | `block/custom` | Wires TrajectoryCalculator on swing, spawns GolfBallEntity to animate |
+| `GolfBallEntity.java` | `entity/custom` | Ticks along ShotResult path, places block at REST, handles hole-in |
+| `GolfBallEntityRenderer.java` | `entity/client` | Renders golf ball item at entity's interpolated position |
 
 ### ✅ Complete
 - Sub-block positioning — `subX`/`subZ` (0–2) stored in BlockEntity NBT, used as shot origin and set from `restNode` after simulation
@@ -32,10 +34,12 @@ net.astellismodding.golfwithmates
 ### ✅ Complete
 - Sub-block visual rendering — BER `ItemDisplayContext.NONE` + `translate(0.5 + offsetX, 0.5, 0.5 + offsetZ)`, dynamic VoxelShape from sub-cell
 
+### ✅ Complete
+- Animation system — on swing, block is removed and `GolfBallEntity` spawns; entity ticks along path nodes at `nodesPerTick` speed (targets ~60 ticks); places `GolfBallBlock` at REST when done
+
 ### 🔲 Next to implement (in order)
 1. Hole detection in `TrajectoryCalculator` (currently stubbed `false`)
 2. `ShotType` enum wiring into `simulateParabolicShot` (IRON/DRIVER/WEDGE)
-3. **Animation system** — block→entity→block (see below)
 
 ---
 
@@ -55,7 +59,9 @@ Physics and rendering are fully decoupled.
 | `TrajectoryCalculator` | Orchestrates simulation — calls PhysicsUtils, reads world for collisions, returns `ShotResult` |
 | `PathNode` | Single point in the path — position, velocity, speed, NodeType |
 | `ShotResult` | Full output of one shot — immutable list of PathNodes + metadata |
-| `GolfBallBlockEntity` | Stores `ShotResult`, sub-cell position, animation tick (pinned), NBT + sync |
+| `GolfBallBlockEntity` | Stores `ShotResult`, sub-cell position, NBT + sync. Resting state only — no animation logic. |
+| `GolfBallEntity` | Temporary entity that animates the ball along the path, then converts back to block at REST |
+| `GolfBallEntityRenderer` | Renders golf ball item at entity's interpolated position (`translate(0, 0.5, 0)` + `NONE` context) |
 | `ClubUtils` | Stat lookup only — `isClub()`, `getShotType()`, `getVelocity()`, `getBounciness()` |
 
 ### Shot Types
@@ -120,23 +126,26 @@ itemRenderer.renderStatic(ballStack, ItemDisplayContext.NONE, ...);
 Both the offset and shape use the same sub-cell values, so visual and hitbox stay in sync.
 Upgrading to finer grid in future = change the divisor in both places.
 
-### Animation System (block → entity → block)
+### Animation System (block → entity → block) ✅
 On swing the ball temporarily becomes an entity that lerps along the `ShotResult` path,
 then converts back to a block at the `REST` position. Block handles persistence; entity handles motion.
 
 **Server-side flow:**
 1. Simulate shot → get `ShotResult`
 2. Remove ball block, spawn `GolfBallEntity` at current position with `ShotResult` attached
-3. Entity ticks along path nodes at a fixed rate
-4. On reaching the `REST` node: place `GolfBallBlock` at that position, copy NBT (incl. `subX`/`subZ` computed from `restNode.position`), remove entity
-5. **Fallback**: if chunk unloads mid-animation, entity death handler places the block immediately so the ball is never lost
+3. Entity ticks along path nodes — `nodesPerTick = max(1, path.size() / 60)` targets ~3 sec animation regardless of path density
+4. On reaching `REST`: compute sub-cell from rest position, place `GolfBallBlock`, copy all metadata (name, puttCounter, shotResult, subPos), remove entity
+5. Hole-in check runs in `GolfBallEntity.placeBlock()` — same logic as old `GolfBallBlock.teleportToResult`
+6. **Persistence fallback**: entity saves full state to NBT — if server restarts mid-animation, entity resumes and places the block when it reaches the end
 
 **Client-side:**
-- Entity syncs `ShotResult` via `FriendlyByteBuf` on spawn (data already serialisable — same NBT format)
-- Client lerps smoothly between nodes; `NodeType` drives effects (bounce sound on `BOUNCE`, roll particles on `ROLL`)
-- Server timing and client animation run independently — server places the block after a pre-calculated tick count based on path length
+- `GolfBallEntity` implements `IEntityWithComplexSpawn` — sends `ShotResult` + `nodesPerTick` to client via spawn packet
+- Client entity ticks independently along the same path at the same rate
+- Standard MC entity position interpolation (`xo/yo/zo` → `x/y/z`) gives smooth lerp between nodes within each tick via `partialTick`
 
-**Key constraint:** The `ShotResult` serialisation is already solved (PathNode NBT). The entity just reuses it.
+**Renderer:**
+- `GolfBallEntityRenderer` renders the golf ball item with `translate(0, 0.5, 0)` + `ItemDisplayContext.NONE`
+- Same pattern as the BER — Y=0.5 lift needed because model geometry sits at Y≈0 in block space
 
 ### Simulation Loop (TrajectoryCalculator)
 - **Iterative, not recursive** — old approach was heading toward stack overflow on long shots
@@ -168,9 +177,8 @@ then converts back to a block at the `REST` position. Block handles persistence;
 - Putter uses `calculateFlatLaunchVelocity()` which calls `calculateLaunchVelocity()` with `launchAngle=0`
 
 ### GolfBallBlockEntity
-- `ShotResult currentShot` — full simulation output
+- `ShotResult currentShot` — full simulation output (resting state only — animation is handled by `GolfBallEntity`)
 - `int subX`, `int subZ` — sub-cell position (0–2 each), default `(1, 1)`
-- `int animationTick`, `boolean animationDone` — pinned, leave unused until animation system
 - `isActive` and `puttCounter` stay as-is
 - `setChangedAndUpdate()` pattern used for all state changes that need client sync
 

--- a/src/main/java/net/astellismodding/golfwithmates/block/custom/GolfBallBlock.java
+++ b/src/main/java/net/astellismodding/golfwithmates/block/custom/GolfBallBlock.java
@@ -1,13 +1,10 @@
 package net.astellismodding.golfwithmates.block.custom;
 
 import com.mojang.serialization.MapCodec;
-import net.astellismodding.golfwithmates.block.entity.BeamBlockEntity;
 import net.astellismodding.golfwithmates.block.entity.GolfBallBlockEntity;
-import net.astellismodding.golfwithmates.component.ModDataComponent;
-import net.astellismodding.golfwithmates.init.ModBlockEntities;
+import net.astellismodding.golfwithmates.entity.custom.GolfBallEntity;
 import net.astellismodding.golfwithmates.sound.ModSounds;
 import net.astellismodding.golfwithmates.util.ClubUtils;
-import net.astellismodding.golfwithmates.util.PathNode;
 import net.astellismodding.golfwithmates.util.ShotResult;
 import net.astellismodding.golfwithmates.util.TrajectoryCalculator;
 import net.minecraft.core.BlockPos;
@@ -126,20 +123,15 @@ public class GolfBallBlock extends BaseEntityBlock {
             double speed = ClubUtils.getVelocity(club) * ClubUtils.getMaxDistance(club) * 30;
 
             ShotResult result = TrajectoryCalculator.simulatePutterShot(startPos, yaw, speed, level);
-            golfBall.setShotResult(result);
-            golfBall.setActive(true);
 
-            PathNode restNode = result.getRestNode();
-            if (restNode != null) {
-                // Compute sub-cell from the rest position and store before teleport
-                Vec3 restPos = restNode.position;
-                int newSubX = Math.min(2, (int)((restPos.x - Math.floor(restPos.x)) * 3));
-                int newSubZ = Math.min(2, (int)((restPos.z - Math.floor(restPos.z)) * 3));
-                golfBall.setSubPos(newSubX, newSubZ);
+            // Capture metadata before removing the block
+            int nextPuttCount = golfBall.getPuttCounter() + 1;
 
-                BlockPos targetBlockPos = BlockPos.containing(restNode.position);
-                teleportToResult(targetBlockPos, state, level, pos);
-            }
+            // Spawn entity to animate along the path — it will place the block when done
+            GolfBallEntity ballEntity = GolfBallEntity.create(
+                    level, startPos, result, golfBall.getCustomName(), nextPuttCount);
+            level.addFreshEntity(ballEntity);
+            level.removeBlock(pos, false);
         }
 
         return ItemInteractionResult.sidedSuccess(level.isClientSide);
@@ -195,6 +187,7 @@ public class GolfBallBlock extends BaseEntityBlock {
 
     public boolean CheckHole(BlockPos context, Level level) {
         BlockPos postion = context.below();
+        //todo: Check subspace location, centre requrired
         Block BlockUnderBall = level.getBlockState(postion).getBlock();
         if ( BlockUnderBall instanceof GolfCupBlock ) {
             return true;

--- a/src/main/java/net/astellismodding/golfwithmates/entity/ModEntities.java
+++ b/src/main/java/net/astellismodding/golfwithmates/entity/ModEntities.java
@@ -2,6 +2,7 @@ package net.astellismodding.golfwithmates.entity;
 
 import net.astellismodding.golfwithmates.GolfWithMates;
 import net.astellismodding.golfwithmates.entity.custom.AppaEntity;
+import net.astellismodding.golfwithmates.entity.custom.GolfBallEntity;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
@@ -17,6 +18,13 @@ public class ModEntities {
     public static final Supplier<EntityType<AppaEntity>> APPA =
             ENTITY_TYPES.register("appa", () -> EntityType.Builder.of(AppaEntity::new, MobCategory.CREATURE)
                     .sized(1.0f,0.35f).build("appa"));
+
+    public static final Supplier<EntityType<GolfBallEntity>> GOLF_BALL_ENTITY =
+            ENTITY_TYPES.register("golf_ball_entity", () -> EntityType.Builder
+                    .<GolfBallEntity>of(GolfBallEntity::new, MobCategory.MISC)
+                    .sized(0.25f, 0.25f)
+                    .clientTrackingRange(64)
+                    .build("golf_ball_entity"));
 
 
 

--- a/src/main/java/net/astellismodding/golfwithmates/entity/client/GolfBallEntityRenderer.java
+++ b/src/main/java/net/astellismodding/golfwithmates/entity/client/GolfBallEntityRenderer.java
@@ -1,0 +1,46 @@
+package net.astellismodding.golfwithmates.entity.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.astellismodding.golfwithmates.entity.custom.GolfBallEntity;
+import net.astellismodding.golfwithmates.init.ModBlocks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+
+public class GolfBallEntityRenderer extends EntityRenderer<GolfBallEntity> {
+
+    public GolfBallEntityRenderer(EntityRendererProvider.Context context) {
+        super(context);
+        this.shadowRadius = 0.1f;
+    }
+
+    @Override
+    public void render(GolfBallEntity entity, float entityYaw, float partialTick,
+                       PoseStack poseStack, MultiBufferSource bufferSource, int packedLight) {
+        poseStack.pushPose();
+        // The golf ball model geometry is centered at (8, 1, 8) in 0-16 space = (0.5, 0.0625, 0.5)
+        // in block coords. Scale 2x to get a visible 0.25-block ball, then shift XZ so the
+        // model center lands on the entity position rather than 0.5 blocks offset.
+        poseStack.translate(0, 0.5, 0);
+        poseStack.scale(1.0f, 1.0f, 1.0f);
+        ItemStack ballStack = new ItemStack(ModBlocks.GOLF_BALL.get().asItem());
+        Minecraft.getInstance().getItemRenderer().renderStatic(
+                ballStack, ItemDisplayContext.NONE,
+                packedLight, OverlayTexture.NO_OVERLAY,
+                poseStack, bufferSource,
+                entity.level(), entity.getId()
+        );
+        poseStack.popPose();
+        super.render(entity, entityYaw, partialTick, poseStack, bufferSource, packedLight);
+    }
+
+    @Override
+    public ResourceLocation getTextureLocation(GolfBallEntity entity) {
+        return ResourceLocation.withDefaultNamespace("textures/misc/white.png");
+    }
+}

--- a/src/main/java/net/astellismodding/golfwithmates/entity/custom/GolfBallEntity.java
+++ b/src/main/java/net/astellismodding/golfwithmates/entity/custom/GolfBallEntity.java
@@ -1,0 +1,171 @@
+package net.astellismodding.golfwithmates.entity.custom;
+
+import net.astellismodding.golfwithmates.block.custom.GolfBallBlock;
+import net.astellismodding.golfwithmates.block.custom.GolfCupBlock;
+import net.astellismodding.golfwithmates.block.entity.GolfBallBlockEntity;
+import net.astellismodding.golfwithmates.entity.ModEntities;
+import net.astellismodding.golfwithmates.init.ModBlocks;
+import net.astellismodding.golfwithmates.sound.ModSounds;
+import net.astellismodding.golfwithmates.util.PathNode;
+import net.astellismodding.golfwithmates.util.ShotResult;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.neoforge.entity.IEntityWithComplexSpawn;
+
+public class GolfBallEntity extends Entity implements IEntityWithComplexSpawn {
+
+    /** Target animation duration in ticks (~3 seconds). nodesPerTick is derived from this. */
+    private static final int TARGET_ANIMATION_TICKS = 60;
+
+    private ShotResult shotResult = ShotResult.empty();
+    private int pathIndex = 0;
+    private int nodesPerTick = 1;
+    private Component customName = Component.literal("Default Name");
+    private int puttCounter = 0;
+
+    public GolfBallEntity(EntityType<?> type, Level level) {
+        super(type, level);
+        this.noPhysics = true;
+    }
+
+    /**
+     * Factory — call this instead of the constructor.
+     * Sets spawn position, shot data, and computes playback speed.
+     */
+    public static GolfBallEntity create(Level level, Vec3 spawnPos, ShotResult shot,
+                                        Component name, int putts) {
+        GolfBallEntity entity = new GolfBallEntity(ModEntities.GOLF_BALL_ENTITY.get(), level);
+        entity.setPos(spawnPos.x, spawnPos.y, spawnPos.z);
+        entity.shotResult = shot;
+        entity.customName = name;
+        entity.puttCounter = putts;
+        entity.nodesPerTick = Math.max(1, shot.path.size() / TARGET_ANIMATION_TICKS);
+        return entity;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tick — advance along path, place block when done
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void tick() {
+        super.tick();
+
+        pathIndex += nodesPerTick;
+
+        if (pathIndex >= shotResult.path.size()) {
+            if (!level().isClientSide) {
+                placeBlock();
+                discard();
+            }
+            return;
+        }
+
+        PathNode node = shotResult.path.get(pathIndex);
+        setPos(node.position.x, node.position.y, node.position.z);
+    }
+
+    /**
+     * Called on the server when the entity reaches the end of the path.
+     * Places the GolfBallBlock at the REST position and restores all metadata.
+     * Also checks for hole-in.
+     */
+    private void placeBlock() {
+        PathNode restNode = shotResult.getRestNode();
+        if (restNode == null || !(level() instanceof ServerLevel serverLevel)) return;
+
+        Vec3 restPos = restNode.position;
+        BlockPos targetPos = BlockPos.containing(restPos);
+
+        if (!serverLevel.getBlockState(targetPos).isAir()) return;
+        if (!serverLevel.getWorldBorder().isWithinBounds(targetPos)) return;
+
+        int newSubX = Math.min(2, (int) ((restPos.x - Math.floor(restPos.x)) * 3));
+        int newSubZ = Math.min(2, (int) ((restPos.z - Math.floor(restPos.z)) * 3));
+
+        BlockState ballState = ModBlocks.GOLF_BALL.get().defaultBlockState();
+        serverLevel.setBlock(targetPos, ballState, 3);
+
+        if (serverLevel.getBlockEntity(targetPos) instanceof GolfBallBlockEntity newBE) {
+            newBE.setCustomName(customName);
+            newBE.setPuttCounter(puttCounter);
+            newBE.setShotResult(shotResult);
+            newBE.setSubPos(newSubX, newSubZ);
+            newBE.setActive(true);
+            newBE.setChanged();
+        }
+
+        // Check for hole-in
+        if (serverLevel.getBlockState(targetPos.below()).getBlock() instanceof GolfCupBlock) {
+            serverLevel.playSeededSound(null,
+                    targetPos.getX(), targetPos.getY(), targetPos.getZ(),
+                    ModSounds.GolfScore, SoundSource.BLOCKS, 1f, 1f, 0);
+            if (serverLevel.getBlockEntity(targetPos) instanceof GolfBallBlockEntity be
+                    && ModBlocks.GOLF_BALL.get() instanceof GolfBallBlock ballBlock) {
+                ballBlock.TransferToCup(be, targetPos, serverLevel);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // IEntityWithComplexSpawn — sends ShotResult to client on entity spawn
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void writeSpawnData(RegistryFriendlyByteBuf buf) {
+        buf.writeNbt(shotResult.toNbt());
+        buf.writeInt(nodesPerTick);
+        buf.writeUtf(customName.getString());
+        buf.writeInt(puttCounter);
+    }
+
+    @Override
+    public void readSpawnData(RegistryFriendlyByteBuf buf) {
+        CompoundTag tag = buf.readNbt();
+        shotResult = tag != null ? ShotResult.fromNbt(tag) : ShotResult.empty();
+        nodesPerTick = buf.readInt();
+        customName = Component.literal(buf.readUtf());
+        puttCounter = buf.readInt();
+    }
+
+    // -------------------------------------------------------------------------
+    // NBT — server-side persistence (chunk unload / server restart fallback)
+    // -------------------------------------------------------------------------
+
+    @Override
+    protected void addAdditionalSaveData(CompoundTag tag) {
+        if (!shotResult.path.isEmpty()) {
+            tag.put("ShotResult", shotResult.toNbt());
+        }
+        tag.putInt("PathIndex", pathIndex);
+        tag.putInt("NodesPerTick", nodesPerTick);
+        tag.putString("CustomName", customName.getString());
+        tag.putInt("PuttCounter", puttCounter);
+    }
+
+    @Override
+    protected void readAdditionalSaveData(CompoundTag tag) {
+        if (tag.contains("ShotResult")) {
+            shotResult = ShotResult.fromNbt(tag.getCompound("ShotResult"));
+        }
+        pathIndex = tag.getInt("PathIndex");
+        nodesPerTick = Math.max(1, tag.getInt("NodesPerTick"));
+        customName = Component.literal(tag.getString("CustomName"));
+        puttCounter = tag.getInt("PuttCounter");
+    }
+
+    @Override
+    protected void defineSynchedData(SynchedEntityData.Builder builder) {
+        // No synced data needed — ShotResult is sent once via spawn packet
+    }
+}

--- a/src/main/java/net/astellismodding/golfwithmates/event/ClientEvents.java
+++ b/src/main/java/net/astellismodding/golfwithmates/event/ClientEvents.java
@@ -5,6 +5,8 @@ import net.astellismodding.golfwithmates.block.entity.renderer.BeamBlockEntityRe
 import net.astellismodding.golfwithmates.block.entity.renderer.GolfBallBlockEntityRender;
 import net.astellismodding.golfwithmates.block.entity.renderer.GolfCupBlockEntityRenderer;
 import net.astellismodding.golfwithmates.block.entity.renderer.NameplateBlockEntityRenderer;
+import net.astellismodding.golfwithmates.entity.ModEntities;
+import net.astellismodding.golfwithmates.entity.client.GolfBallEntityRenderer;
 import net.astellismodding.golfwithmates.init.ModBlockEntities;
 import net.astellismodding.golfwithmates.network.PuttPowerPayload;
 import net.astellismodding.golfwithmates.network.StrokePowerPayload;
@@ -88,6 +90,10 @@ public class ClientEvents {
             event.registerBlockEntityRenderer(
                     ModBlockEntities.GOLF_BALL_BE.get(),
                     GolfBallBlockEntityRender::new
+            );
+            event.registerEntityRenderer(
+                    ModEntities.GOLF_BALL_ENTITY.get(),
+                    GolfBallEntityRenderer::new
             );
         }
             }


### PR DESCRIPTION
…lt path, converts back to block at REST

- Add GolfBallEntity: ticks along ShotResult path nodes at nodesPerTick speed (targets ~60 ticks), places GolfBallBlock at REST with full metadata restore and hole-in check; implements IEntityWithComplexSpawn to send ShotResult to client on spawn; full NBT persistence as fallback
- Add GolfBallEntityRenderer: renders golf ball item with translate(0, 0.5, 0) + NONE context
- Register golf_ball_entity in ModEntities and its renderer in ClientEvents
- Update GolfBallBlock.useItemOn: replace instant teleport with entity spawn + block removal
- Update CLAUDE.md: mark animation system complete, update class table and architecture notes